### PR TITLE
Add testing option to run with a test-db-server

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,15 +7,15 @@ const ObjectID = require('mongodb').ObjectID
 const Base = require('bfx-facs-base')
 const fmt = require('util').format
 
-function client (conf, label, cb) {
-  let url = (process.env.MONGO_DB_TEST_URI)
-    ? process.env.MONGO_DB_TEST_URI
+function client (conf, opts, cb) {
+  let url = (opts.mongoUri)
+    ? opts.mongoUri
     : fmt(
       'mongodb://%s:%s@%s:%s/%s?authMechanism=DEFAULT&maxPoolSize=' + (conf.maxPoolSize || 150),
       conf.user, conf.password, conf.host, conf.port, conf.database
     )
 
-  if (conf.rs && !process.env.MONGO_DB_TEST_URI) {
+  if (conf.rs && !opts.mongoUri) {
     url += `&replicaSet=${conf.rs}`
   }
   Mongo.connect(url, cb)
@@ -42,7 +42,7 @@ class MongoFacility extends Base {
         client(_.pick(
           this.conf,
           ['user', 'password', 'database', 'host', 'port', 'rs', 'maxPoolSize']
-        ), null, (err, cli) => {
+        ), this.opts, (err, cli) => {
           if (err) return next(err)
 
           this.cli = cli


### PR DESCRIPTION
Add an option as to run with a test-db like a memory-server as to do tests without affecting the data.
Server example: https://github.com/nodkz/mongodb-memory-server